### PR TITLE
Added stdexcept header dependency.

### DIFF
--- a/src/keyboard/keyboard.cpp
+++ b/src/keyboard/keyboard.cpp
@@ -1,3 +1,5 @@
+#include <stdexcept>
+
 #include <SFML/Graphics/RenderTarget.hpp>
 #include <SFML/Graphics/RenderStates.hpp>
 


### PR DESCRIPTION
The added include is necessary to compile with my "gcc (Debian 4.7.2-5) 4.7.2".
Otherwise the "std::overflow_error" is unknow.
