### PR TITLE
Fix some cppcheck reports

### DIFF
--- a/src/libmidi/midi.cpp
+++ b/src/libmidi/midi.cpp
@@ -37,10 +37,10 @@ Midi Midi::read_from_file(const string &filename) {
 
     try {
         midi = read_from_stream(file);
-    } catch (const MidiError &e) {
+    } catch (const MidiError &) {
         // Close our file resource before handing the error up
         file.close();
-        throw e;
+        throw;
     }
     return midi;
 }

--- a/src/libmidi/midi_track.cpp
+++ b/src/libmidi/midi_track.cpp
@@ -164,7 +164,7 @@ void MidiTrack::build_note_set() {
         activeNotes[id] = info;
     }
 
-    if (activeNotes.size() > 0) {
+    if (!activeNotes.empty()) {
         // LOGTODO!
 
         // This is mostly non-critical.

--- a/src/libmidi/midi_track.h
+++ b/src/libmidi/midi_track.h
@@ -105,7 +105,7 @@ public:
      * (vs. just being an information track with a title or copyright)
      */
     bool has_notes() const {
-        return noteSet.size() > 0;
+        return (!noteSet.empty());
     
     }
 


### PR DESCRIPTION
There are still these (if we exclude the cppcheck reports pointing on src-old):
[src/libmidi/midi_event.h:61]: (warning) Member variable 'MidiEvent::deltaPulses' is not initialized in the constructor.
[src/libmidi/midi_event.h:61]: (warning) Member variable 'MidiEvent::metaType' is not initialized in the constructor.
[src/screens/one_player_screen/note_ground.cpp:21]: (warning) Member variable 'NoteGround::microSecondPerPixel' is not initialized in the constructor.
but perhaps it's on purpose.
