### PR TITLE
Relative paths

### DIFF
--- a/src/assets/path.h
+++ b/src/assets/path.h
@@ -4,5 +4,12 @@
 #define GRAPHICS_DIR "../graphics/"
 #define FONTS_DIR "../fonts/"
 #define DEFAULT_FONT FONTS_DIR "FaunaOne-Regular.ttf"
+#define MIDI_DIR "../songs/"
+
+extern std::string gblExecutableDir;
+extern std::string gblGraphicsDir;
+extern std::string gblFontsDir;
+extern std::string gblMidiDir;
+extern std::string gblDefaultFont;
 
 #endif

--- a/src/buttons/long_one_line_button.cpp
+++ b/src/buttons/long_one_line_button.cpp
@@ -19,7 +19,7 @@ sf::Font LongOneLineButton::font = sf::Font();
  */
 void LongOneLineButton::init() {
 
-    const std::string BUTTON = GRAPHICS_DIR "longbutton.png";
+    const std::string BUTTON = gblGraphicsDir + "longbutton.png";
     if (!texture.loadFromFile(BUTTON)) {
         std::cerr
             << "Can't load "
@@ -29,10 +29,10 @@ void LongOneLineButton::init() {
     }
     texture.setSmooth(true);
 
-    if (!font.loadFromFile(DEFAULT_FONT)) {
+    if (!font.loadFromFile(gblDefaultFont)) {
         std::cerr
             << "Can't load "
-            << DEFAULT_FONT
+            << gblDefaultFont
             << std::endl
         ;
     }

--- a/src/buttons/short_one_line_button.cpp
+++ b/src/buttons/short_one_line_button.cpp
@@ -18,7 +18,7 @@ sf::Font ShortOneLineButton::font = sf::Font();
  *
  */
 void ShortOneLineButton::init() {
-    const std::string BUTTON = GRAPHICS_DIR "button.png";
+    const std::string BUTTON = gblGraphicsDir + "button.png";
     if (!texture.loadFromFile(BUTTON)) {
         std::cerr
             << "Can't load "
@@ -28,10 +28,10 @@ void ShortOneLineButton::init() {
     }
     texture.setSmooth(true);
 
-    if (!font.loadFromFile(DEFAULT_FONT)) {
+    if (!font.loadFromFile(gblDefaultFont)) {
         std::cerr
             << "Can't load "
-            << DEFAULT_FONT
+            << gblDefaultFont
             << std::endl
         ;
     }

--- a/src/buttons/two_lines_button.cpp
+++ b/src/buttons/two_lines_button.cpp
@@ -25,7 +25,7 @@ TwoLinesButton::TwoLinesButton(
     const unsigned INTER_LINE_SPACE = 15;
     currentState = ButtonStates::NORMAL;
 
-    const std::string BUTTON = GRAPHICS_DIR "button2line.png";
+    const std::string BUTTON = gblGraphicsDir + "button2line.png";
     if (!texture.loadFromFile(BUTTON)) {
         std::cerr
             << "Can't load "
@@ -36,10 +36,10 @@ TwoLinesButton::TwoLinesButton(
     texture.setSmooth(true);
     sprite.setTexture(texture);
 
-    if (!font.loadFromFile(DEFAULT_FONT)) {
+    if (!font.loadFromFile(gblDefaultFont)) {
         std::cerr
             << "Can't load "
-            << DEFAULT_FONT
+            << gblDefaultFont
             << std::endl
         ;
     }

--- a/src/icons/icon.cpp
+++ b/src/icons/icon.cpp
@@ -17,7 +17,7 @@ sf::Texture Icon::iconsTexture = sf::Texture();
  *
  */
 void Icon::init() {
-    const std::string INTERFACE_BUTTONS = GRAPHICS_DIR "InterfaceButtons.tga";
+    const std::string INTERFACE_BUTTONS = gblGraphicsDir + "InterfaceButtons.tga";
     if (!iconsTexture.loadFromFile(INTERFACE_BUTTONS)) {
         std::cerr
             << "Can't load "

--- a/src/keyboard/trail.cpp
+++ b/src/keyboard/trail.cpp
@@ -12,7 +12,7 @@ namespace linthesia {
  */
 KeyboardTrail::KeyboardTrail() {
     const std::string TOP_SEPARATOR =
-        GRAPHICS_DIR
+        gblGraphicsDir +
         "keyboard_top_separator.png"
     ;
     if (!texture.loadFromFile(TOP_SEPARATOR)) {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -5,6 +5,8 @@
 #include "screens/screens.h"
 #include "context/context.h"
 
+#include "assets/path.h"
+
 //TODO should not be needed
 #include "buttons/short_one_line_button.h"
 #include "buttons/long_one_line_button.h"
@@ -13,8 +15,26 @@
 
 using namespace std;
 
+/* Set some sensible defaults for the global paths. */
+string gblExecutableDir = "";
+string gblGraphicsDir = "";
+string gblFontsDir = "";
+string gblDefaultFont = "";
+string gblMidiDir = "";
 
-int main() {
+static void setPaths(const string &exeDir)
+{
+    size_t idx = exeDir.find_last_of("/\\");
+    gblExecutableDir = exeDir.substr(0, idx);
+    gblGraphicsDir = gblExecutableDir + "/" + GRAPHICS_DIR;
+    gblFontsDir = gblExecutableDir + "/" + FONTS_DIR;
+    gblMidiDir = gblExecutableDir + "/" + MIDI_DIR;
+    gblDefaultFont = gblFontsDir + DEFAULT_FONT;
+}
+
+int main(int argc, char *argv[]) {
+
+    setPaths(argv[0]);
 
     sf::RenderWindow application(
         sf::VideoMode(800, 600),

--- a/src/midi_io/midi_in.cpp
+++ b/src/midi_io/midi_in.cpp
@@ -59,7 +59,7 @@ void MidiIn::open() {
     try {
         rtMidiIn.openPort(chosenPort);
     }
-    catch (RtMidiError &error) {
+    catch (RtError &error) {
         error.printMessage();
     }
 }

--- a/src/screens/file_select_screen/file_select_screen.cpp
+++ b/src/screens/file_select_screen/file_select_screen.cpp
@@ -3,7 +3,7 @@
 
 #include "utilities/tinydir.h"
 #include "file_select_screen.h"
-
+#include "assets/path.h"
 #include "context/context.h"
 
 namespace linthesia {
@@ -12,11 +12,6 @@ namespace linthesia {
  *
  */
 const ScreenIndex FileSelectScreen::INDEX = "file_select_screen";
-
-/**
- *
- */
-const static std::string MIDI_DIR_PATH("../songs/");
 
 /**
  *
@@ -87,7 +82,7 @@ ScreenIndex FileSelectScreen::run(
     sf::Event event;
 
     // we initalize the file selector list
-    midiFileNames = get_midi_files(MIDI_DIR_PATH);
+    midiFileNames = get_midi_files(gblMidiDir);
     fileButtons.clear();
     for (auto fileName : midiFileNames) {
         fileButtons.push_back(LongOneLineButton(fileName));
@@ -204,7 +199,7 @@ bool FileSelectScreen::actionTriggeredFileButtons(
                 return;
             }
             std::string filename = midiFileNames[currentButton + fileIndex];
-            if (!context.openMidiFile(MIDI_DIR_PATH + filename)) {
+            if (!context.openMidiFile(gblMidiDir + filename)) {
                 return;
             }
             oneFileChosen = true;

--- a/src/screens/main_screen/main_screen.cpp
+++ b/src/screens/main_screen/main_screen.cpp
@@ -34,7 +34,7 @@ MainScreen::MainScreen() :
     selectTrackButton("play"),
     chooseSongButton("song:", "no song selected yet")
 {
-    const std::string LOGO = GRAPHICS_DIR "title_Logo.png";
+    const std::string LOGO = gblGraphicsDir + "title_Logo.png";
     if (!logoTexture.loadFromFile(LOGO)) {
         std::cerr
             << "Can't load "

--- a/src/screens/main_screen/select_midi_in.cpp
+++ b/src/screens/main_screen/select_midi_in.cpp
@@ -47,7 +47,7 @@ SelectMidiIn::SelectMidiIn() :
         INTER_LINE_SPACE;
 
 
-    const std::string BUTTON = GRAPHICS_DIR "button2line.png";
+    const std::string BUTTON = gblGraphicsDir + "button2line.png";
     if (!backgroundTexture.loadFromFile(BUTTON)) {
         std::cerr
             << "Can't load "
@@ -76,10 +76,10 @@ SelectMidiIn::SelectMidiIn() :
         SECOND_LINE_Y
     );
 
-    if (!font.loadFromFile(DEFAULT_FONT)) {
+    if (!font.loadFromFile(gblDefaultFont)) {
         std::cerr
             << "Can't load "
-            << DEFAULT_FONT
+            << gblDefaultFont
             << std::endl
         ;
     }

--- a/src/screens/main_screen/select_midi_out.cpp
+++ b/src/screens/main_screen/select_midi_out.cpp
@@ -47,7 +47,7 @@ SelectMidiOut::SelectMidiOut() :
         CHARACTER_SIZE +
         INTER_LINE_SPACE;
 
-    const std::string BUTTON = GRAPHICS_DIR "button2line.png";
+    const std::string BUTTON = gblGraphicsDir + "button2line.png";
     if (!backgroundTexture.loadFromFile(BUTTON)) {
         std::cerr
             << "Can't load "
@@ -83,10 +83,10 @@ SelectMidiOut::SelectMidiOut() :
     );
 
 
-    if (!font.loadFromFile(DEFAULT_FONT)) {
+    if (!font.loadFromFile(gblDefaultFont)) {
         std::cerr
             << "Can't load "
-            << DEFAULT_FONT
+            << gblDefaultFont
             << std::endl
         ;
     }

--- a/src/screens/one_player_screen/one_player_screen.cpp
+++ b/src/screens/one_player_screen/one_player_screen.cpp
@@ -62,7 +62,7 @@ ScreenIndex OnePlayerScreen::run(
     //TODO move all these "init*" in a function made for that
     // and or see a better way to avoid that polluating this
     // function
-    font.loadFromFile(DEFAULT_FONT);
+    font.loadFromFile(gblDefaultFont);
     sf::Event event;
 
     sf::Clock clock;
@@ -405,10 +405,10 @@ void OnePlayerScreen::scrollNoteGround(
 void OnePlayerScreen::initSpeedLabel(
     const sf::RenderWindow &app
 ) {
-    if (!font.loadFromFile(DEFAULT_FONT)) {
+    if (!font.loadFromFile(gblDefaultFont)) {
         std::cerr
             << "Can't load "
-            << DEFAULT_FONT
+            << gblDefaultFont
             << std::endl
         ;
     }

--- a/src/screens/one_player_screen/score_display.cpp
+++ b/src/screens/one_player_screen/score_display.cpp
@@ -20,7 +20,7 @@ static std::string padZero(unsigned number) {
 
     std::ostringstream ss;
     ss << std::setw(4) << std::setfill('0') << number;
-    return ss.str(); 
+    return ss.str();
 }
 
 
@@ -29,14 +29,14 @@ static std::string padZero(unsigned number) {
  */
 void ScoreDisplay::init() {
 
-    if (!font.loadFromFile(DEFAULT_FONT)) {
+    if (!font.loadFromFile(gblDefaultFont)) {
         std::cerr
             << "Can't load "
-            << DEFAULT_FONT
+            << gblDefaultFont
             << std::endl
         ;
     }
-    const std::string STAR = GRAPHICS_DIR "star.png";
+    const std::string STAR = gblGraphicsDir + "star.png";
     if (!star.loadFromFile(STAR)) {
         std::cerr
             << "Can't load "
@@ -47,7 +47,7 @@ void ScoreDisplay::init() {
     //star.setSmooth(true);
     starSprite.setTexture(star);
 
-    const std::string THUMB_DOWN = GRAPHICS_DIR "thumb_down.png";
+    const std::string THUMB_DOWN = gblGraphicsDir + "thumb_down.png";
     if (!thumbdown.loadFromFile(THUMB_DOWN)) {
         std::cerr
             << "Can't load "
@@ -73,7 +73,7 @@ void ScoreDisplay::init() {
         sf::Color(200, 200, 50),
         x,
         y
-    ); 
+    );
     // ~ green
     x += SIZE_COUNTER;
     initLabel(
@@ -98,7 +98,7 @@ void ScoreDisplay::init() {
         sf::Color(50, 200, 50),
         x,
         y
-    ); 
+    );
     // ~red
     x += SIZE_COUNTER;
     thumbdownSprite.setPosition(x, ICON_PADDING_TOP);

--- a/src/screens/select_track_screen/track_box.cpp
+++ b/src/screens/select_track_screen/track_box.cpp
@@ -20,7 +20,7 @@ sf::Font TrackBox::font = sf::Font();
  *
  */
 void TrackBox::init() {
-    const std::string TRACKBOX_FILE = GRAPHICS_DIR "trackbox.png";
+    const std::string TRACKBOX_FILE = gblGraphicsDir + "trackbox.png";
     if (!backgroundTexture.loadFromFile(TRACKBOX_FILE)) {
         std::cerr
             << "Can't load "
@@ -30,10 +30,10 @@ void TrackBox::init() {
     }
     backgroundTexture.setSmooth(true);
 
-    if (!font.loadFromFile(DEFAULT_FONT)) {
+    if (!font.loadFromFile(gblDefaultFont)) {
         std::cerr
             << "Can't load "
-            << DEFAULT_FONT
+            << gblDefaultFont
             << std::endl
         ;
     }


### PR DESCRIPTION
I realised just as I created this pull request that my "fix" for the RtMidiError bug was not a fix at all, the API was renamed in version 2.1 and I'm using 2.0 (so much for semantic versioning)

Anyway the rest of this pull request is good, I't allows the binary to be run from any directory, 
i.e you can `make` and then `./src/linthesia` without having to `cd`

i.e. the paths to the graphics and fonts are relative to the executable dir not the present working dir.