### PR TITLE
Write correct speed even when returning to the OnePlayerScreen

### DIFF
--- a/src/screens/one_player_screen/one_player_screen.cpp
+++ b/src/screens/one_player_screen/one_player_screen.cpp
@@ -415,7 +415,7 @@ void OnePlayerScreen::initSpeedLabel(const sf::RenderWindow &app) {
     }
     speedLabel.setFont(font);
     speedLabel.setColor(sf::Color(200, 165, 0));
-    speedLabel.setString("speed: 1");
+    updateSpeedLabel();
 
     float yPosition = app.getSize().y - SPACE_BUTTONS / 2;
 

--- a/src/screens/select_track_screen/select_track_screen.cpp
+++ b/src/screens/select_track_screen/select_track_screen.cpp
@@ -89,8 +89,9 @@ ScreenIndex SelectTrackScreen::run(
         app.clear(BACKGROUND_COLOR);
         app.draw(backButton);
         app.draw(startGameButton);
-        for (const auto &trackBox : allTrackBoxes) {
+        for (auto &trackBox : allTrackBoxes) {
             app.draw(trackBox);
+            trackBox.updatePlayChoiceLabel(context.tracksOptions);
         }
         app.display();
 

--- a/src/screens/select_track_screen/track_box.cpp
+++ b/src/screens/select_track_screen/track_box.cpp
@@ -62,7 +62,6 @@ TrackBox::TrackBox(
 
     const std::string instrument("Instrument:");
     const std::string notes("Notes:");
-    const std::string playChoice("Played automatically");
     const unsigned BUTTON_PADDING = 15;
     const unsigned CHARACTER_SIZE = 15;
     const unsigned INTER_LINE_SPACE = 10;
@@ -141,16 +140,21 @@ TrackBox::TrackBox(
 
 
 
-
-    // init the part displaying the midi output used
     playChoiceLabel.setFont(font);
     playChoiceLabel.setCharacterSize(CHARACTER_SIZE);
-    playChoiceLabel.setString(playChoice);
+    // "playChoiceLabel.setString()" will be called when the track will have been chosen
     playChoiceLabel.setPosition(
         BUTTON_PADDING + ICON_WIDTH,
         // we center text in the middle of the icon
         CHOICE_LINE_Y + (ICON_WIDTH - CHARACTER_SIZE) / 2.0f
     );
+}
+
+void TrackBox::updatePlayChoiceLabel(
+    linthesia::TrackOptions  &trackOptions
+) {
+        const std::string style = trackOptions.getStrStyle(trackId);
+        playChoiceLabel.setString(style);
 }
 
 /**

--- a/src/screens/select_track_screen/track_box.h
+++ b/src/screens/select_track_screen/track_box.h
@@ -48,6 +48,10 @@ class TrackBox : public sf::Drawable , public sf::Transformable {
             linthesia::TrackOptions &TrackOptions
         );
 
+        void updatePlayChoiceLabel(
+            linthesia::TrackOptions &TrackOptions)
+        ;
+
     private:
         /**
          *

--- a/src/track_options/track_options.cpp
+++ b/src/track_options/track_options.cpp
@@ -89,6 +89,10 @@ PlayStyle TrackOptions::getStyle(unsigned trackId) {
     return trackidStyle[trackId];
 }
 
+const std::string TrackOptions::getStrStyle(unsigned trackId) {
+    return style2name[trackidStyle[trackId]];
+}
+
 /**
  *
  */

--- a/src/track_options/track_options.h
+++ b/src/track_options/track_options.h
@@ -59,6 +59,8 @@ class TrackOptions {
          */
         PlayStyle getStyle(unsigned trackId);
 
+        const std::string getStrStyle(unsigned trackId);
+
     private:
         /**
          * store the track style by trackId


### PR DESCRIPTION
If you set a speed (e.g. 1/2), you go back to the previous screen and return to the OnePlayerScreen. "speed: 1" was displayed but the last selected speed was still in memory (if you decreased or increased the speed, you will notice).